### PR TITLE
HIL pin map fix

### DIFF
--- a/hil/hil_devices/hil_device_test_pcb.json
+++ b/hil/hil_devices/hil_device_test_pcb.json
@@ -2,14 +2,11 @@
     "$schema": "./emulator_schema.json",
     "communication_mode":"serial",
     "ports":[
-        {"port":0, "name":"DI1", "capabilities":["DI"], "notes":"digital input 5V-30V"},
-        {"port":1, "name":"DI2", "capabilities":["DI"], "notes":"digital input 5V-30V"},
         {"port":16, "name":"DI3", "capabilities":["DI"], "notes":"digital input 5V-30V"},
         {"port":14, "name":"DI4", "capabilities":["DI"], "notes":"digital input 5V-30V"},
         {"port":15, "name":"DI5", "capabilities":["DI"], "notes":"digital input 5V-30V"},
         {"port":8, "name":"DI6", "capabilities":["DI"], "notes":"digital input 5V-30V"},
         {"port":4, "name":"DI7", "capabilities":["DI"], "notes":"digital input 5V-30V"},
-        {"port":2, "name":"DI8", "capabilities":["DI"], "notes":"digital input 5V-30V"},
         {"port":18, "name":"AI1", "capabilities":["DI", "AI", "DO"], "notes":"analog / digital input 5V"},
         {"port":19, "name":"AI2", "capabilities":["DI", "AI", "DO"], "notes":"analog / digital input 5V"},
         {"port":20, "name":"AI3", "capabilities":["DI", "AI", "DO"], "notes":"analog / digital input 5V"},
@@ -18,10 +15,9 @@
         {"port":11, "name":"RLY2", "capabilities":["DO"], "notes":"relay"},
         {"port":12, "name":"RLY3", "capabilities":["DO"], "notes":"relay"},
         {"port":13, "name":"RLY4", "capabilities":["DO"], "notes":"relay"},
-        {"port":3, "name":"DAC1", "capabilities":["DO", "AO"], "notes":"5V 8-bit DAC"},
-        {"port":5, "name":"DAC2", "capabilities":["DO", "AO"], "notes":"5V 8-bit DAC"},
-        {"port":6, "name":"DAC3", "capabilities":["DO", "AO"], "notes":"5V 8-bit DAC"},
-        {"port":9, "name":"DAC4", "capabilities":["DO", "AO"], "notes":"5V 8-bit DAC"}
+        {"port":0, "name":"DAC1", "capabilities":["AO"], "notes":"5V 12-bit DAC"},
+        {"port":1, "name":"DAC2", "capabilities":["AO"], "notes":"5V 12-bit DAC"}
     ],
-   "adc_config":{"bit_resolution":10, "reference_v":5.0}
+   "adc_config":{"bit_resolution":10, "reference_v":5.0},
+   "dac_Config":{"bit_resolution":12, "reference_v":5.0}
 }


### PR DESCRIPTION
HIL test PCB has pins that cannot be used due to assignments to Tx/Rx for UART and SCL/SDA. Resulted in removal of digital input silkscreen labels DI1,DI2,DI8.