### PR TITLE
feature/millan/arbitraryData Size

### DIFF
--- a/TestBench/TestBench.ino
+++ b/TestBench/TestBench.ino
@@ -64,9 +64,13 @@ char data[4] = {-1, -1, -1, -1};
 int data_index = 0;
 bool data_ready = false;
 
+bool led_builtin_state = false;
+
 
 void setup() {
 	SERIAL.begin(115200);
+
+	digitalWrite(LED_BUILTIN, led_builtin_state);
 
 #ifdef DIGIPOT_EN
 	// Setting up Digipot 1
@@ -98,6 +102,9 @@ void loop() {
 	if (data_ready) {
 		data_ready = false;
 		data_index = 0;
+
+		led_builtin_state = !led_builtin_state;
+		digitalWrite(LED_BUILTIN, led_builtin_state);
 
 		GpioCommand command = (GpioCommand) data[0];
 
@@ -157,7 +164,6 @@ void loop() {
 			if (1) {
 				pinMode(pin, OUTPUT);
 				digitalWrite(pin, value);
-				digitalWrite(LED_BUILTIN, value);
 			} else {
 				error("GPIO PIN COUNT EXCEEDED");
 			}

--- a/TestBench/TestBench.ino
+++ b/TestBench/TestBench.ino
@@ -101,7 +101,7 @@ void loop() {
 
 		GpioCommand command = (GpioCommand) data[0];
 
-		switch (expression) {
+		switch (command) {
 		case GpioCommand::READ_ADC: {
 			int pin = data[1];
 			// if (pin <= ANALOG_PIN_COUNT)

--- a/hil/hil_devices/hil_device_arduino_mil_pcb.json
+++ b/hil/hil_devices/hil_device_arduino_mil_pcb.json
@@ -36,11 +36,11 @@
 
         {"port":9, "name":"3v3ref", "capabilities":["AI"], "notes":"3V3 input reference"},
 
-        {"port":200, "name":"DAC1", "capabilities":["AO"], "notes":"5V ~8-bit DAC"},
-        {"port":201, "name":"DAC2", "capabilities":["AO"], "notes":"5V ~8-bit DAC"}
+        {"port":200, "name":"DAC1", "capabilities":["AO"], "notes":"5V 12-bit DAC"},
+        {"port":201, "name":"DAC2", "capabilities":["AO"], "notes":"5V 12-bit DAC"}
     ],
    "adc_config":{"bit_resolution":10, "reference_v":5.0},
-   "dac_config":{"bit_resolution":8, "reference_v":5.0},
+   "dac_config":{"bit_resolution":12, "reference_v":5.0},
    "pot_config":{"bit_resolution":6},
    "calibrate_rail":false
 }

--- a/hil/hil_devices/serial_manager.py
+++ b/hil/hil_devices/serial_manager.py
@@ -26,8 +26,8 @@ class SerialManager():
             ard.setDTR(True)
             # Uno takes a while startup, have to treat it nicely
             for _ in range(5):
-                # Get Tester id - [command, pin, value], but we only care about the pin
-                ard.write(b'\x04\x00\x00')
+                # 4 = HIL_CMD_READ_ID
+                ard.write(b'\x04')
                 i = ard.read(1)
                 if (len(i) == 1):
                     break


### PR DESCRIPTION
Large redesign of serial Python -> Arduino code 
- Instead of it always being [command, pin, value] it is now [command, ...] 
- This allows: 
    - Read requests to not need to send a useless/dummy value 
    - Write requests to send values higher than 2^8 (- 1) 
        - Just bit shift the value and chop it into 2^8 sized sections 
- Tested with simple example and it seems to work 