### PR TITLE
Dash tests for 2025

### DIFF
--- a/configurations/config_system_hil_attached.json
+++ b/configurations/config_system_hil_attached.json
@@ -15,8 +15,8 @@
         {"board":"Dashboard", "harness_connections":[
             {"dut":{"connector":"J1","pin":9},  "hil":{"device":"FrontTester", "port":"DAC1"}},
             {"dut":{"connector":"J1","pin":10}, "hil":{"device":"FrontTester", "port":"DAC2"}},
-            {"dut":{"connector":"J1","pin":11}, "hil":{"device":"FrontTester", "port":"POT1"}},
-            {"dut":{"connector":"J1","pin":12}, "hil":{"device":"FrontTester", "port":"POT2"}}
+            {"dut":{"connector":"J1","pin":11}, "hil":{"device":"FrontTester", "port":"DAC1", "_": "can't do breaks and throttle at once, not enough DACs"}},
+            {"dut":{"connector":"J1","pin":12}, "hil":{"device":"FrontTester", "port":"DAC2"}}
         ]}
     ],
     "hil_devices":[

--- a/scripts/node_specific/scripts/test_dash.py
+++ b/scripts/node_specific/scripts/test_dash.py
@@ -175,13 +175,12 @@ def test_bspd(hil):
 # ---------------------------------------------------------------------------- #
 
 
-# TODO: add throttle checks
-
 # ---------------------------------------------------------------------------- #
 THROTTLE_VARIANCE = 0.1
 
-
-def test_throttle(hil):
+# 0-5V throttle sweep with 0.2 step
+@pytest.mark.parametrize("voltage", [x / 10.0 for x in range(0, 52, 2)])
+def test_throttle(hil, voltage):
     # HIL outputs (hil writes)
     thrtl1 = hil.aout("Dashboard", "THRTL1_RAW")
     thrtl2 = hil.aout("Dashboard", "THRTL2_RAW")
@@ -190,28 +189,23 @@ def test_throttle(hil):
     thrtl1_flt = hil.mcu_pin("Dashboard", "THRTL1_FLT")
     thrtl2_flt = hil.mcu_pin("Dashboard", "THRTL2_FLT")
 
-    # 0-5V throttle sweep with 0.2
     throttle_values = [x / 10.0 for x in range(0, 52, 2)]
     random.shuffle(throttle_values)
 
-    # Sweep throttle 1
-    for v in throttle_values:
-        thrtl1.state = v
-        time.sleep(0.1)
-        check.almost_equal(
-            thrtl1_flt.state, v,
-            abs=THROTTLE_VARIANCE, rel=0.0,
-            msg=f"Throttle 1: {v}V"
-        )
-    
-    # Sweep throttle 2
-    for v in throttle_values:
-        thrtl2.state = v
-        time.sleep(0.1)
-        check.almost_equal(
-            thrtl2_flt.state, v,
-            abs=THROTTLE_VARIANCE, rel=0.0,
-            msg=f"Throttle 2: {v}V"
-        )
+    thrtl1.state = voltage
+    time.sleep(0.1)
+    check.almost_equal(
+        thrtl1_flt.state, voltage,
+        abs=THROTTLE_VARIANCE, rel=0.0,
+        msg=f"Throttle 1: {voltage}V"
+    )
+
+    thrtl2.state = voltage
+    time.sleep(0.1)
+    check.almost_equal(
+        thrtl2_flt.state, voltage,
+        abs=THROTTLE_VARIANCE, rel=0.0,
+        msg=f"Throttle 2: {voltage}V"
+    )
 # ---------------------------------------------------------------------------- #
 

--- a/scripts/node_specific/scripts/test_dash.py
+++ b/scripts/node_specific/scripts/test_dash.py
@@ -34,6 +34,26 @@ BRK_SWEEP_DELAY = 0.1
 def test_bspd(hil):
     # Begin the test
     # hil.start_test(test_bspd.__name__)
+"""
+0v: Brake released
+5v: Fully pressed
+
+test_bspd (brake signal plausibility detection)
+
+BSE (Brake System Encoder)
+- T.4.3.4
+    - When an analogue signal is used, the BSE sensors will be considered to have failed when they
+        achieve an open circuit or short circuit condition which generates a signal outside of the
+        normal operating range, for example <0.5 V or >4.5 V.
+
+APPS (Accelerator Pedal Position Sensor)
+- T.4.2.4:
+    - Implausibility is defined as a deviation of more than 10% Pedal Travel between the sensors or
+        other failure as defined in this Section T.4.2.
+- T.4.2.5:
+    - If an Implausibility occurs between the values of the APPSs and persists for more than 100
+        msec, the power to the (IC) Electronic Throttle / (EV) Motor(s) must be immediately stopped completely.
+"""
 
     # Outputs
     brk1    = hil.aout("Dashboard",   "BRK1_RAW")

--- a/scripts/node_specific/scripts/test_dash.py
+++ b/scripts/node_specific/scripts/test_dash.py
@@ -31,9 +31,6 @@ def hil():
 # ---------------------------------------------------------------------------- #
 BRK_SWEEP_DELAY = 0.1
 
-def test_bspd(hil):
-    # Begin the test
-    # hil.start_test(test_bspd.__name__)
 """
 0v: Brake released
 5v: Fully pressed
@@ -55,46 +52,49 @@ APPS (Accelerator Pedal Position Sensor)
         msec, the power to the (IC) Electronic Throttle / (EV) Motor(s) must be immediately stopped completely.
 """
 
-    # Outputs
-    brk1    = hil.aout("Dashboard",   "BRK1_RAW")
-    brk2    = hil.aout("Dashboard",   "BRK2_RAW")
 
-    # Inputs
+def test_bspd(hil):
+    # HIL outputs (hil writes)
+    brk1 = hil.aout("Dashboard", "BRK1_RAW")
+    brk2 = hil.aout("Dashboard", "BRK2_RAW")
+
+    # HIL inputs (hil reads)
     brk_fail_tap = hil.mcu_pin("Dashboard", "BRK_FAIL_TAP")
     brk_stat_tap = hil.mcu_pin("Dashboard", "BRK_STAT_TAP")
 
-    # Brake threshold check
+    # Brakes 1 and 2 are at rest
     brk1.state = BRK_1_REST_V
     brk2.state = BRK_2_REST_V
-    # hil.check(brk_stat_tap.state == 0, "Brake stat starts low")
-    check.equal(brk_stat_tap.state, 0, "Brake stat starts low")
+    time.sleep(0.1)
+    check.equal(brk_stat_tap.state, 0, f"Brakes 1 ({BRK_1_REST_V}) and 2 ({BRK_2_REST_V}) -> rests")
 
+    # Brake 1 trips
     brk1.state = BRK_1_THRESH_V
     time.sleep(0.1)
-    # hil.check(brk_stat_tap.state == 1, "Brake stat goes high at brk 1 thresh")
-    check.equal(brk_stat_tap.state, 1, "Brake stat goes high at brk 1 thresh")
+    check.equal(brk_stat_tap.state, 1, f"Brake 1 ({BRK_1_THRESH_V}) -> trips")
 
+    # Brake 1 resets -> rest
     brk1.state = BRK_1_REST_V
-    # hil.check(brk_stat_tap.state == 0, "Brake stat starts low")
-    check.equal(brk_stat_tap.state, 0, "Brake stat starts low")
+    time.sleep(0.1)
+    check.equal(brk_stat_tap.state, 0, f"Brake 1 ({BRK_1_REST_V}) -> rests")
 
+    # Brake 2 trips
     brk2.state = BRK_2_THRESH_V
     time.sleep(0.1)
-    # hil.check(brk_stat_tap.state == 1, "Brake stat goes high at brk 2 thresh")
-    check.equal(brk_stat_tap.state, 1, "Brake stat goes high at brk 2 thresh")
+    check.equal(brk_stat_tap.state, 1, f"Brake 2 ({BRK_2_THRESH_V}) -> trips")
 
+    # Brake 1 high -> still tripped
     brk1.state = BRK_1_THRESH_V
-    # hil.check(brk_stat_tap.state == 1, "Brake stat stays high for both brakes")
-    check.equal(brk_stat_tap.state, 1, "Brake stat stays high for both brakes")
+    time.sleep(0.1)
+    check.equal(brk_stat_tap.state, 1, f"Brakes (1 -> {BRK_1_REST_V}) stay tripped")
 
-
-    # Brake threshold scan
+    # Reset both brakes
     brk1.state = BRK_MIN_OUT_V
     brk2.state = BRK_MIN_OUT_V
     time.sleep(0.1)
-    # hil.check(brk_stat_tap.state == 0, "Brake Stat Starts Low Brk 1")
-    check.equal(brk_stat_tap.state, 0, "Brake Stat Starts Low Brk 1")
+    check.equal(brk_stat_tap.state, 0, f"Brakes 1 ({BRK_MIN_OUT_V}) and 2 ({BRK_MIN_OUT_V}) -> rests")
 
+    # Brake 1 trips at the correct voltage
     start = BRK_MIN_OUT_V
     stop  = BRK_MAX_OUT_V
     step  = 0.1
@@ -103,97 +103,95 @@ APPS (Accelerator Pedal Position Sensor)
                                        BRK_SWEEP_DELAY,
                                        brk_stat_tap, is_falling=False)
     print(f"Brake 1 braking threshold: {thresh}")
-    # hil.check_within(thresh, BRK_1_THRESH_V, 0.2, "Brake 1 trip voltage")
-    # hil.check(brk_stat_tap.state == 1, "Brake Stat Tripped for Brk 1")
     check.almost_equal(
         thresh, BRK_1_THRESH_V,
         abs=0.2, rel=0.0,
-        msg="Brake 1 trip voltage"
+        msg="Brake 1 trips at correct voltage"
     )
-    check.equal(brk_stat_tap.state, 1, "Brake Stat Tripped for Brk 1")
+    check.equal(brk_stat_tap.state, 1, "Brake 1 tripped")
 
+    # Reset both brakes
     brk1.state = BRK_MIN_OUT_V
     brk2.state = BRK_MIN_OUT_V
-    hil.check(brk_stat_tap.state == 0, "Brake Stat Starts Low Brk 2")
+    time.sleep(0.1)
+    hil.check(brk_stat_tap.state == 0, f"Brakes 1 ({BRK_MIN_OUT_V}) and 2 ({BRK_MIN_OUT_V}) -> rests")
+    
+    # Brake 2 trips at the correct voltage
     thresh = utils.measure_trip_thresh(brk2, start, stop, step,
                                        BRK_SWEEP_DELAY,
                                        brk_stat_tap, is_falling=False)
     print(f"Brake 2 braking threshold: {thresh}")
-    # hil.check_within(thresh, BRK_2_THRESH_V, 0.2, "Brake 2 trip voltage")
-    # hil.check(brk_stat_tap.state == 1, "Brake Stat Tripped for Brk 2")
     check.almost_equal(
         thresh, BRK_2_THRESH_V,
         abs=0.2, rel=0.0,
-        msg="Brake 2 trip voltage"
+        msg="Brake 2 trips at correct voltage"
     )
-    check.equal(brk_stat_tap.state, 1, "Brake Stat Tripped for Brk 2")
+    check.equal(brk_stat_tap.state, 1, "Brake 2 tripped")
 
-    # Brake Fail scan
+
+    # Brakes at rest
     brk1.state = BRK_1_REST_V
     brk2.state = BRK_2_REST_V
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 0, "Brake Fail Check 1 Starts 0")
-    check.equal(brk_fail_tap.state, 0, "Brake Fail Check 1 Starts 0")
+    check.equal(brk_fail_tap.state, 0, f"Brakes 1 ({BRK_1_REST_V}) and 2 ({BRK_2_REST_V}) -> no fail")
 
-    brk1.state = 0.0 # Force 0
+    # Brake 1 forced to 0V (short to GND)
+    brk1.state = 0.0
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 1, "Brake Fail Brk 1 Short GND")
-    check.equal(brk_fail_tap.state, 1, "Brake Fail Brk 1 Short GND")
+    check.equal(brk_fail_tap.state, 1, "Brake 1 short to GND -> fail")
 
+    # Reset brake 1
     brk1.state = BRK_1_REST_V
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 0, "Brake Fail Check 2 Starts 0")
-    check.equal(brk_fail_tap.state, 0, "Brake Fail Check 2 Starts 0")
+    check.equal(brk_fail_tap.state, 0, "Brake 1 reset -> no fail")
 
-    brk2.state = 0.0 # Force 0
+    # Brake 2 forced to 0V (short to GND)
+    brk2.state = 0.0
     time.sleep(0.1)
-    hil.check(brk_fail_tap.state == 1, "Brake Fail Brk 2 Short GND")
-    check.equal(brk_fail_tap.state, 1, "Brake Fail Brk 2 Short GND")
+    check.equal(brk_fail_tap.state, 1, "Brake 2 short to GND -> fail")
 
+    # Reset brake 2
     brk2.state = BRK_2_REST_V
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 0, "Brake Fail Check 3 Starts 0")
-    check.equal(brk_fail_tap.state, 0, "Brake Fail Check 3 Starts 0")
+    check.equal(brk_fail_tap.state, 0, "Brake 2 reset -> no fail")
 
-    brk1.state = 5.0 # Short VCC
+    # Brake 1 forced to 5V (short to VCC)
+    brk1.state = 5.0
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 1, "Brake Fail Brk 1 Short VCC")
-    check.equal(brk_fail_tap.state, 1, "Brake Fail Brk 1 Short VCC")
+    check.equal(brk_fail_tap.state, 1, "Brake 1 short to VCC -> fail")
 
+    # Reset brake 1
     brk1.state = BRK_1_REST_V
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 0, "Brake Fail Check 4 Starts 0")
-    check.equal(brk_fail_tap.state, 0, "Brake Fail Check 4 Starts 0")
+    check.equal(brk_fail_tap.state, 0, "Brake 1 reset -> no fail")
 
-    brk2.state = 5.0 # Short VCC
+    # Brake 2 forced to 5V (short to VCC)
+    brk2.state = 5.0
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 1, "Brake Fail Brk 2 Short VCC")
-    check.equal(brk_fail_tap.state, 1, "Brake Fail Brk 2 Short VCC")
+    check.equal(brk_fail_tap.state, 1, "Brake 2 short to VCC -> fail")
 
+    # Reset brake 2
     brk2.state = BRK_2_REST_V
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 0, "Brake Fail Check 5 Starts 0")
-    check.equal(brk_fail_tap.state, 0, "Brake Fail Check 5 Starts 0")
+    check.equal(brk_fail_tap.state, 0, "Brake 2 reset -> no fail")
 
+    # Brake 1 Hi-Z
     brk1.hiZ()
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 1, "Brake Fail Brk 1 Hi-Z")
-    check.equal(brk_fail_tap.state, 1, "Brake Fail Brk 1 Hi-Z")
+    check.equal(brk_fail_tap.state, 1, "Brake 1 Hi-Z -> fail")
 
+    # Reset brake 1
     brk1.state = BRK_1_REST_V
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 0, "Brake Fail Check 6 Starts 0")
-    check.equal(brk_fail_tap.state, 0, "Brake Fail Check 6 Starts 0")
+    check.equal(brk_fail_tap.state, 0, "Brake 1 reset -> no fail")
 
+    # Brake 2 Hi-Z
     brk2.hiZ()
     time.sleep(0.1)
-    # hil.check(brk_fail_tap.state == 1, "Brake Fail Brk 2 Hi-Z")
-    check.equal(brk_fail_tap.state, 1, "Brake Fail Brk 2 Hi-Z")
+    check.equal(brk_fail_tap.state, 1, "Brake 2 Hi-Z -> fail")
 
+    # Reset brake 2
     brk2.state = BRK_2_REST_V
-
-    # End the test
-    # hil.end_test()
 # ---------------------------------------------------------------------------- #
 
 

--- a/scripts/node_specific/scripts/test_dash.py
+++ b/scripts/node_specific/scripts/test_dash.py
@@ -5,7 +5,6 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 from hil.hil import HIL
 import hil.utils as utils
 import time
-import random
 from scripts.common.constants.rules_constants import *
 from scripts.common.constants.vehicle_constants import *
 
@@ -188,9 +187,6 @@ def test_throttle(hil, voltage):
     # HIL inputs (hil reads)
     thrtl1_flt = hil.mcu_pin("Dashboard", "THRTL1_FLT")
     thrtl2_flt = hil.mcu_pin("Dashboard", "THRTL2_FLT")
-
-    throttle_values = [x / 10.0 for x in range(0, 52, 2)]
-    random.shuffle(throttle_values)
 
     thrtl1.state = voltage
     time.sleep(0.1)

--- a/scripts/node_specific/scripts/test_dash.py
+++ b/scripts/node_specific/scripts/test_dash.py
@@ -32,7 +32,7 @@ def hil():
 BRK_SWEEP_DELAY = 0.1
 
 """
-0v: Brake released
+0v: Released
 5v: Fully pressed
 
 test_bspd (brake signal plausibility detection)
@@ -49,7 +49,14 @@ APPS (Accelerator Pedal Position Sensor)
         other failure as defined in this Section T.4.2.
 - T.4.2.5:
     - If an Implausibility occurs between the values of the APPSs and persists for more than 100
-        msec, the power to the (IC) Electronic Throttle / (EV) Motor(s) must be immediately stopped completely.
+        msec, the power to the (IC) Electronic Throttle / (EV) Motor(s) must be immediately stopped
+        completely.
+- T.4.2.10:
+    - When an analogue signal is used, the APPS will be considered to have failed when they achieve
+        an open circuit or short circuit condition which generates a signal outside of the normal
+        operating range, for example <0.5 V or >4.5 V.
+
+
 """
 
 
@@ -196,3 +203,25 @@ def test_bspd(hil):
 
 
 # TODO: add throttle checks
+
+# ---------------------------------------------------------------------------- #
+def test_throttle(hil):
+    # HIL outputs (hil writes)
+    thrtl1 = hil.aout("Dashboard", "THRTL1_RAW")
+    thrtl2 = hil.aout("Dashboard", "THRTL2_RAW")
+
+    # HIL inputs (hil reads)
+    # TODO: CAN??????????
+
+
+    # Test set 1: throttles at rest
+    # Test set 2: throttle 1 trips
+    # Test set 3: throttle 2 trips
+    # Test set 4: throttle 1 and 2 trip
+    # Test set 5: throttle 1 and 2 trip at the correct voltage
+    # Test set 6: throttle 1 and 2 at rest
+
+
+    # Test throttle high and brakes high
+# ---------------------------------------------------------------------------- #
+


### PR DESCRIPTION
Should be basically the same as before but:
- Has the old hil.checks removed
- New throttle tests using DACs (note, old boards only have 2 DACs, so can't run the brakes and throttle tests at once)
  - (Just tests THRTL1_RAW = THRTL1_FLT)
- Slightly improved test messages