### PR TITLE
Discharge test

### DIFF
--- a/configurations/config_system_hil_attached.json
+++ b/configurations/config_system_hil_attached.json
@@ -21,7 +21,7 @@
         {"board":"Discharge", "harness_connections":[
             {"dut":{"connector":"P7","pin":3},  "hil":{"device":"RearTester", "port":"DI3"}},
             {"dut":{"connector":"P1","pin":1},  "hil":{"device":"RearTester", "port":"AI1"}},
-            {"dut":{"connector":"P2","pin":10}, "hil":{"device":"RearTester", "port":"AI2"}}
+            {"dut":{"connector":"P2","pin":10}, "hil":{"device":"RearTester", "port":"RLY1"}}
         ]}
     ],
     "hil_devices":[

--- a/configurations/config_system_hil_attached.json
+++ b/configurations/config_system_hil_attached.json
@@ -17,6 +17,11 @@
             {"dut":{"connector":"J1","pin":10}, "hil":{"device":"FrontTester", "port":"DAC2"}},
             {"dut":{"connector":"J1","pin":11}, "hil":{"device":"FrontTester", "port":"POT1"}},
             {"dut":{"connector":"J1","pin":12}, "hil":{"device":"FrontTester", "port":"POT2"}}
+        ]},
+        {"board":"Discharge", "harness_connections":[
+            {"dut":{"connector":"P7","pin":3},  "hil":{"device":"RearTester", "port":"DI3"}},
+            {"dut":{"connector":"P1","pin":1},  "hil":{"device":"RearTester", "port":"AI1"}},
+            {"dut":{"connector":"P2","pin":10}, "hil":{"device":"RearTester", "port":"AI2"}}
         ]}
     ],
     "hil_devices":[

--- a/scripts/node_specific/scripts/test_discharge.py
+++ b/scripts/node_specific/scripts/test_discharge.py
@@ -38,15 +38,18 @@ def hil():
 ])
 def test_main_relay(hil, tsms_set, hv_plus_set, discharge_plus_expected):
     # HIL outputs (hil writes)
-    tsms    = hil.dout("Discharge", "SDC15 - TSMS")
+
+    # WIRING NOTE: SDC15 - TSMS is 24V logic, Arudino max voltage is 5V
+    # So instead, HIL will control the relay and 24V will be wired through the relay
+    tsms_hil_relay = hil.dout("Discharge", "SDC15 - TSMS")
     hv_plus = hil.dout("Discharge", "HV+")
 
     # HIL inputs (hil reads)
     discharge_plus = hil.din("Discharge", "discharge+")
 
-    tsms.state = tsms_set
+    tsms_hil_relay.state = not tsms_set # HIL relay is inverted
     hv_plus.state = hv_plus_set
-    time.sleep(0.1)
+    time.sleep(0.2)
 
     message = f"TSMS: {tsms_set}, HV+: {hv_plus_set} -> Discharge+: {discharge_plus_expected}"
     check.equal(discharge_plus.state, discharge_plus_expected, message)

--- a/scripts/node_specific/scripts/test_discharge.py
+++ b/scripts/node_specific/scripts/test_discharge.py
@@ -1,0 +1,53 @@
+from os import sys, path
+# adds "./HIL-Testing" to the path, basically making it so these scripts were run one folder level higher
+sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
+
+from hil.hil import HIL
+import hil.utils as utils
+import time
+from scripts.common.constants.rules_constants import *
+from scripts.common.constants.vehicle_constants import *
+
+import pytest_check as check
+import pytest
+
+
+# ---------------------------------------------------------------------------- #
+@pytest.fixture(scope="session")
+def hil():
+    hil_instance = HIL()
+
+    # TODO: new config file
+    hil_instance.load_config("config_system_hil_attached.json")
+    hil_instance.load_pin_map("per_24_net_map.csv", "stm32f407_pin_map.csv")
+
+    hil_instance.init_can()
+
+    yield hil_instance
+
+    hil_instance.shutdown()
+# ---------------------------------------------------------------------------- #
+
+
+# ---------------------------------------------------------------------------- #
+@pytest.mark.parametrize("tsms_set, hv_plus_set, discharge_plus_expected", [
+    (0, 0, 0), # TSMS low, HV+ low -> discharge disconnected (0)
+    (1, 0, 0), # TSMS high, HV+ low -> discharge connected but no voltage (0)
+    (0, 1, 0), # TSMS low, HV+ high -> discharge disconnected (0)
+    (1, 1, 1), # TSMS high, HV+ high -> discharge connected with voltage (1)
+])
+def test_main_relay(hil, tsms_set, hv_plus_set, discharge_plus_expected):
+    # HIL outputs (hil writes)
+    tsms    = hil.dout("Discharge", "SDC15 - TSMS")
+    hv_plus = hil.dout("Discharge", "HV+")
+
+    # HIL inputs (hil reads)
+    discharge_plus = hil.din("Discharge", "discharge+")
+
+    tsms.state = tsms_set
+    hv_plus.state = hv_plus_set
+    time.sleep(0.1)
+
+    message = f"TSMS: {tsms_set}, HV+: {hv_plus_set} -> Discharge+: {discharge_plus_expected}"
+    check.equal(discharge_plus.state, discharge_plus_expected, message)
+# ---------------------------------------------------------------------------- #

--- a/scripts/node_specific/scripts/test_discharge.py
+++ b/scripts/node_specific/scripts/test_discharge.py
@@ -31,10 +31,10 @@ def hil():
 
 # ---------------------------------------------------------------------------- #
 @pytest.mark.parametrize("tsms_set, hv_plus_set, discharge_plus_expected", [
-    (0, 0, 0), # TSMS low, HV+ low -> discharge disconnected (0)
-    (1, 0, 0), # TSMS high, HV+ low -> discharge connected but no voltage (0)
-    (0, 1, 0), # TSMS low, HV+ high -> discharge disconnected (0)
-    (1, 1, 1), # TSMS high, HV+ high -> discharge connected with voltage (1)
+    (1, 0, 0), # TSMS low = relay open, HV+ low -> discharge disconnected (0)
+    (0, 0, 0), # TSMS high = relay closed, HV+ low -> discharge connected but no voltage (0)
+    (1, 1, 0), # TSMS low = relay open, HV+ high -> discharge disconnected (0)
+    (0, 1, 1), # TSMS high = relay closed, HV+ high -> discharge connected with voltage (1)
 ])
 def test_main_relay(hil, tsms_set, hv_plus_set, discharge_plus_expected):
     # HIL outputs (hil writes)


### PR DESCRIPTION
In theory: HIL controls `SDC15 - TSMS` and `HV+` and checks `discharge+`
Uses a HIL relay for `SDC15 - TSMS` to allow 24V logic, simple DO/DI for `HV+` and `discharge+`.
Not fully sure I get which config to put it in, but I think it matches the net map :question: 